### PR TITLE
[RESPONSIVE DESIGN] Added web responsive design to dashboard page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,34 @@ body {
 .image {
     width: 500px
 }
+
+/* Media Queries - Samira */
+
+@media only screen and (max-width: 768px) {
+    /* Adjust font size for smaller screens */
+    .text-lg {
+        font-size: 1rem;
+    }
+
+    /* Stacking buttons on smaller screens */
+    .button-container {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    /* Adjust table column widths for better readability on small screens */
+    .table-cell {
+        min-width: 100px;
+    }
+}
+
+@media (min-width: 768px) { /* Adjust the min-width */
+    .responsive-grid {
+        display: grid;
+        grid-template-columns: 2fr 0.25fr; /* This creates indicates the col's proportions */
+    }
+}
+
+
+

--- a/src/index.css
+++ b/src/index.css
@@ -37,5 +37,16 @@ body {
     }
 }
 
+@media (max-width: 768px) {
+    .dialog-container {
+      position: fixed; /* Stick to the bottom */
+      bottom: 0; /* Align to bottom */
+      left: 0; /* Align to left */
+      width: 100%; /* Full width */
+      border-top: 1px solid #ccc; /* Optional: adds a border top */
+      box-shadow: 0 -2px 4px rgba(0,0,0,0.1); /* Optional: adds a subtle shadow */
+      z-index: 1000; /* Ensure it stays on top */
+    }
+}
 
 

--- a/src/pages/AddTransactionForm.jsx
+++ b/src/pages/AddTransactionForm.jsx
@@ -115,7 +115,7 @@ export default function AddTransactionForm({fetchTransactions}) {
             <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
           </Transition.Child>
   
-          <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+          <div className="fixed inset-0 z-10 w-screen overflow-y-auto dialog-container">
             <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
               <Transition.Child
                 as={Fragment}

--- a/src/pages/TransTable.jsx
+++ b/src/pages/TransTable.jsx
@@ -1,9 +1,9 @@
 import { useProtectedRoute } from "../components/useProtectedRoute";
-import { useState,useEffect } from "react";
+import { useState, useEffect } from "react";
 import AddTransactionForm from "./AddTransactionForm";
 import { useAuth } from "../context/AuthContext";
-import {TrashIcon, PencilSquareIcon} from '@heroicons/react/20/solid'
-import {getTransactionFromDB,getIncome,getSavingGoal,getBudget} from '../utils/firebase-config';
+import { TrashIcon, PencilSquareIcon } from '@heroicons/react/20/solid'
+import { getTransactionFromDB, getIncome, getSavingGoal, getBudget } from '../utils/firebase-config';
 import DeleteConfirm from "./DeleteConfirm";
 import UpdateIncome from "./UpdateIncome";
 import UpdateBudget from "./UpdateBudget";
@@ -11,16 +11,16 @@ import UpdateSavingGoal from "./UpdateSavingGoal";
 
 const TransTable = () => {
     useProtectedRoute();
-    const { currentUser} = useAuth();
+    const { currentUser } = useAuth();
 
-    useEffect(() => {fetchTransactions()},[currentUser])
+    useEffect(() => { fetchTransactions() }, [currentUser])
 
     async function fetchTransactions() {
-        if(currentUser){
-          const data = await getTransactionFromDB(currentUser.uid);
-          setTransactionList(data);
+        if (currentUser) {
+            const data = await getTransactionFromDB(currentUser.uid);
+            setTransactionList(data);
         }
-      }
+    }
 
     const [showTrashIcon, setShowTrashIcon] = useState(false)
 
@@ -33,35 +33,33 @@ const TransTable = () => {
     // total spending 
     const [monthlySpent, setMonthSpent] = useState("")
     const [lastMonthSpent, setLastMonthSpent] = useState("")
-    useEffect(() =>{
+    useEffect(() => {
         const y = new Date().getFullYear().toString(this)
         const m = (new Date().getMonth() + 1).toString(this)
         let sum = 0.0
         transactionList.filter(transcation => {
-          if(transcation.date.split('-')[0] === y && transcation.date.split('-')[1] === m)
-          {
-              sum = sum + parseFloat(transcation.amount)
-          }
+            if (transcation.date.split('-')[0] === y && transcation.date.split('-')[1] === m) {
+                sum = sum + parseFloat(transcation.amount)
+            }
         });
         setMonthSpent(sum.toFixed(2))
-    },[transactionList])
+    }, [transactionList])
 
-    useEffect(() =>{
+    useEffect(() => {
         const y = new Date().getFullYear().toString(this)
         let m = (new Date().getMonth()).toString(this)
         let sum = 0.0
-        if(m === '0'){
+        if (m === '0') {
             m = (new Date().getMonth() + 1).toString(this)
         }
         transactionList.filter(transcation => {
-          if(transcation.date.split('-')[0] === y && transcation.date.split('-')[1] === m)
-          {
-              sum = sum + parseFloat(transcation.amount)
-          }
+            if (transcation.date.split('-')[0] === y && transcation.date.split('-')[1] === m) {
+                sum = sum + parseFloat(transcation.amount)
+            }
         });
         setLastMonthSpent(sum.toFixed(2))
-    },[transactionList,currentUser])
-    
+    }, [transactionList, currentUser])
+
 
     //Income
     const [monthlyIncome, setMonthlyIncome] = useState("")
@@ -70,23 +68,23 @@ const TransTable = () => {
     const [showUpdateIncome, setShowUpdateIncome] = useState(false)
 
     async function getMonthlyIncome() {
-        if(currentUser){
+        if (currentUser) {
             const data = await getIncome(currentUser.uid);
             setMonthlyIncome(data);
-          }
+        }
     }
 
     useEffect(() => {
         setMoneySave((parseFloat(monthlyIncome) - parseFloat(monthlySpent)).toFixed(2))
-    },[currentUser,monthlySpent,monthlyIncome])
+    }, [currentUser, monthlySpent, monthlyIncome])
 
-    useEffect(() => {getMonthlyIncome()},[currentUser])
+    useEffect(() => { getMonthlyIncome() }, [currentUser])
 
     useEffect(() => {
-        if(parseFloat(moneySave).toFixed(2) >= 0){
+        if (parseFloat(moneySave).toFixed(2) >= 0) {
             const percentage = parseFloat(moneySave) / parseFloat(monthlyIncome) * 100
             setMoneySavedPercentage(percentage.toFixed(2))
-        }else{
+        } else {
             setMoneySavedPercentage(0)
         }
 
@@ -98,179 +96,192 @@ const TransTable = () => {
     const [budgetPercentage, setBudgetPercentage] = useState("")
     const [remianingBudget, setRemianingBudget] = useState()
     const [showUpdateBudge, setShowUpdateBudge] = useState(false)
-    useEffect(() => {getMonthlyBudget()},[currentUser])
+    useEffect(() => { getMonthlyBudget() }, [currentUser])
     async function getMonthlyBudget() {
-        if(currentUser){
+        if (currentUser) {
             const data = await getBudget(currentUser.uid);
             setMonthlyBudget(data);
-          }
+        }
     }
-    useEffect(()=>{
-        if(parseFloat(monthlySpent) > parseFloat(monthlyBudget)){
+    useEffect(() => {
+        if (parseFloat(monthlySpent) > parseFloat(monthlyBudget)) {
             setBudgetPercentage("100")
             setRemianingBudget('0')
         }
-        else{
-            const percentage = parseFloat(monthlySpent)/parseFloat(monthlyBudget)
+        else {
+            const percentage = parseFloat(monthlySpent) / parseFloat(monthlyBudget)
             setRemianingBudget((parseFloat(monthlyBudget) - parseFloat(monthlySpent)).toFixed(2))
-            setBudgetPercentage((percentage*100).toFixed(2))
+            setBudgetPercentage((percentage * 100).toFixed(2))
         }
-    },[monthlySpent,monthlyBudget])
+    }, [monthlySpent, monthlyBudget])
 
     //saving goal
     const [savingGoal, setSavingGoal] = useState('')
     const [savingsPercentage, setSavingsPercentage] = useState("")
     const [showUpdateGoal, setShowUpdateGoal] = useState(false)
 
-    useEffect(() => {getSaving()},[currentUser])
+    useEffect(() => { getSaving() }, [currentUser])
 
-    async function getSaving(){
-        if(currentUser){
+    async function getSaving() {
+        if (currentUser) {
             const data = await getSavingGoal(currentUser.uid);
             setSavingGoal(data)
         }
     }
 
-    useEffect(()=>{
-        if(parseFloat(moneySave) > parseFloat(savingGoal)){
+    useEffect(() => {
+        if (parseFloat(moneySave) > parseFloat(savingGoal)) {
             setSavingsPercentage("100")
         }
-        else if(parseFloat(moneySave) < 0){
+        else if (parseFloat(moneySave) < 0) {
             setSavingsPercentage("0")
         }
-        else{
-            const percentage = parseFloat(moneySave)/parseFloat(savingGoal)
-            setSavingsPercentage((percentage*100).toFixed(2))
+        else {
+            const percentage = parseFloat(moneySave) / parseFloat(savingGoal)
+            setSavingsPercentage((percentage * 100).toFixed(2))
         }
-    },[savingGoal,moneySave])
+    }, [savingGoal, moneySave])
 
 
 
     return (
-        <><div className="px-8 pt-8 grid grid-cols-4 gap-5">
-            <div>
-                {/* From Flowbite, data cards */}
-                <span className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
-                    onClick={() => setShowUpdateIncome(!showUpdateIncome)}>
-                    <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">Income: ${monthlyIncome} <PencilSquareIcon className="w-5 h-5 inline-block" /></h5>
-                    {/* <h6 className="font-normal text-gray-700 dark:text-gray-400 ">Monthly Income </h6> */}
-                    <div className="flex justify-between mb-1">
-                        <span className="text-base font-normal text-gray-700 dark:text-gray-400">Remaining : ${moneySave}</span>
-                        <span className="text-sm font-medium text-darkblue dark:text-white">{moneySavedPercentage}%</span>
-                    </div>
-                    <div className="w-full bg-lightblue rounded-full h-2.5 dark:bg-gray-900">
-                        <div className="bg-darkblue h-2.5 rounded-full dark:bg-green" style={{ width: `${moneySavedPercentage}%` }}></div>
-                    </div>
-                    {showUpdateIncome && 
-                        <UpdateIncome
-                            showUpdateIncome = {showUpdateIncome}
-                            setShowUpdateIncome ={setShowUpdateIncome}
-                            setMonthlyIncome = {setMonthlyIncome}
-                    />}
-                </span>
-            </div>
-            <div>
-                <a href="#" className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700">
-                    <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">{`$${monthlySpent}`}</h5>
-                    <p className="font-normal text-gray-700 dark:text-gray-400">Monthly Spent</p>
-                    <p className="font-normal text-gray-700 dark:text-gray-400">Last Month: ${lastMonthSpent}</p>
-                </a>
-            </div>
-            <div>
-                <span className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700" onClick={() => setShowUpdateBudge(!showUpdateBudge)}>
-                    <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">{`$${remianingBudget}`} <PencilSquareIcon className="w-5 h-5 inline-block" /></h5>
-{/*                     <p className="font-normal text-gray-700 dark:text-gray-400">Remaining Budget</p> */}
-                    <div className="flex justify-between mb-1">
-                        <span className="text-base font-normal text-gray-700 dark:text-gray-400">Budget: ${monthlyBudget}</span>
-                        <span className="text-sm font-medium text-darkblue dark:text-white">budget used: {budgetPercentage}%</span>
-                    </div>
-                    <div className="w-full bg-lightblue rounded-full h-2.5 dark:bg-gray-900">
-                        <div className="bg-darkblue h-2.5 rounded-full dark:bg-green" style={{ width: `${budgetPercentage}%` }}></div>
-                    </div>
-                    {showUpdateBudge && <UpdateBudget
-                        showUpdateBudge = {showUpdateBudge}
-                        setShowUpdateBudge = {setShowUpdateBudge}
-                        setMonthlyBudget = {setMonthlyBudget}
-                    />}
-                </span>
-            </div>
-            <div>
+        <>
+            {/* Web Responsiveness - Samira */}
+            {/* Responsive Grid Layout: Adjusts from 1 to 4 columns based on screen size */}
+            <div className="px-4 md:px-8 pt-4 md:pt-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5">
+                <div className="card">
+                    {/* From Flowbite, data cards */}
+                    <span className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
+                        onClick={() => setShowUpdateIncome(!showUpdateIncome)}>
+                        <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">Income: ${monthlyIncome} <PencilSquareIcon className="w-5 h-5 inline-block" /></h5>
+                        {/* <h6 className="font-normal text-gray-700 dark:text-gray-400 ">Monthly Income </h6> */}
+                        <div className="flex justify-between mb-1">
+                            <span className="text-base font-normal text-gray-700 dark:text-gray-400">Remaining : ${moneySave}</span>
+                            <span className="text-sm font-medium text-darkblue dark:text-white">{moneySavedPercentage}%</span>
+                        </div>
+                        <div className="w-full bg-lightblue rounded-full h-2.5 dark:bg-gray-900">
+                            <div className="bg-darkblue h-2.5 rounded-full dark:bg-green" style={{ width: `${moneySavedPercentage}%` }}></div>
+                        </div>
+                        {showUpdateIncome &&
+                            <UpdateIncome
+                                showUpdateIncome={showUpdateIncome}
+                                setShowUpdateIncome={setShowUpdateIncome}
+                                setMonthlyIncome={setMonthlyIncome}
+                            />}
+                    </span>
+                </div>
+                <div className="card">
+                    <a href="#" className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700">
+                        <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">{`$${monthlySpent}`}</h5>
+                        <p className="font-normal text-gray-700 dark:text-gray-400">Monthly Spent</p>
+                        <p className="font-normal text-gray-700 dark:text-gray-400">Last Month: ${lastMonthSpent}</p>
+                    </a>
+                </div>
+                <div className="card">
+                    <span className="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700" onClick={() => setShowUpdateBudge(!showUpdateBudge)}>
+                        <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">{`$${remianingBudget}`} <PencilSquareIcon className="w-5 h-5 inline-block" /></h5>
+                        {/*                     <p className="font-normal text-gray-700 dark:text-gray-400">Remaining Budget</p> */}
+                        <div className="flex justify-between mb-1">
+                            <span className="text-base font-normal text-gray-700 dark:text-gray-400">Budget: ${monthlyBudget}</span>
+                            <span className="text-sm font-medium text-darkblue dark:text-white">budget used: {budgetPercentage}%</span>
+                        </div>
+                        <div className="w-full bg-lightblue rounded-full h-2.5 dark:bg-gray-900">
+                            <div className="bg-darkblue h-2.5 rounded-full dark:bg-green" style={{ width: `${budgetPercentage}%` }}></div>
+                        </div>
+                        {showUpdateBudge && <UpdateBudget
+                            showUpdateBudge={showUpdateBudge}
+                            setShowUpdateBudge={setShowUpdateBudge}
+                            setMonthlyBudget={setMonthlyBudget}
+                        />}
+                    </span>
+                </div>
+                <div className="card">
 
-                <span  onClick ={() => setShowUpdateGoal(!showUpdateGoal) } className="h-36 block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700">
-                    <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">Goal ${savingGoal} <PencilSquareIcon className="w-5 h-5 inline-block" /></h5>
-                    {/* Flowbite Progress Bar */}
-                    <div className="flex justify-between mb-1">
-                        <span className="text-base font-normal text-gray-700 dark:text-gray-400">Actual Saving: ${parseFloat(moneySave)> 0? moneySave : 0}</span>
-                        <span className="text-sm font-medium text-darkblue dark:text-white">{`${savingsPercentage}%`}</span>
-                    </div>
-                    <div className="w-full bg-lightblue rounded-full h-2.5 dark:bg-gray-900">
-                        <div className="bg-darkblue h-2.5 rounded-full dark:bg-green" style={{ width: `${savingsPercentage}%` }}></div>
-                    </div>
-                    <p className="mt-1 text-right italic font-normal text-gray-400 dark:text-gray-400">{`${savingsPercentage}% to goal`}</p>
-                    <UpdateSavingGoal 
-                        showUpdateGoal ={showUpdateGoal}
-                        setShowUpdateGoal = {setShowUpdateGoal}
-                        setSavingGoal ={setSavingGoal}
-                    />
+                    <span onClick={() => setShowUpdateGoal(!showUpdateGoal)} className="h-36 block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700">
+                        <h5 className="mb-2 text-2xl font-bold tracking-tight text-darkblue dark:text-white">Goal ${savingGoal} <PencilSquareIcon className="w-5 h-5 inline-block" /></h5>
+                        {/* Flowbite Progress Bar */}
+                        <div className="flex justify-between mb-1">
+                            <span className="text-base font-normal text-gray-700 dark:text-gray-400">Actual Saving: ${parseFloat(moneySave) > 0 ? moneySave : 0}</span>
+                            <span className="text-sm font-medium text-darkblue dark:text-white">{`${savingsPercentage}%`}</span>
+                        </div>
+                        <div className="w-full bg-lightblue rounded-full h-2.5 dark:bg-gray-900">
+                            <div className="bg-darkblue h-2.5 rounded-full dark:bg-green" style={{ width: `${savingsPercentage}%` }}></div>
+                        </div>
+                        <p className="mt-1 text-right italic font-normal text-gray-400 dark:text-gray-400">{`${savingsPercentage}% to goal`}</p>
+                        <UpdateSavingGoal
+                            showUpdateGoal={showUpdateGoal}
+                            setShowUpdateGoal={setShowUpdateGoal}
+                            setSavingGoal={setSavingGoal}
+                        />
 
-                </span>
+                    </span>
+                </div>
             </div>
-        </div><div className="px-8 py-0 w-full overflow-x-auto">
+            {/* Responsive Table and Form Section */}
+            <div className="px-4 md:px-8 py-4 w-full">
                 <div className="mb-4 text-2xl font-semibold text-darkblue">Recent Activity</div>
-                <div className="grid grid-cols-4 gap-5">
-                    <table className="w-full col-span-3 border-collapse table-auto bg-white rounded-lg shadow">
-                        <thead>
-                            <tr>
-                                <th className="border p-3 bg-gray-100 text-left">Date</th>
-                                <th className="border p-3 bg-gray-100 text-left">Category</th>
-                                <th className="border p-3 bg-gray-100 text-right">Amount</th>
-                                <th className="border p-3 bg-gray-100 text-right">
+                {/* Grid for Table and Form: Single column layout */}
+                <div className="grid grid-cols-1 gap-4 responsive-grid">
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full border-collapse table-auto bg-white rounded-lg shadow">
+                            <thead>
+                                <tr>
+                                    <th className="border p-3 bg-gray-100 text-left">Date</th>
+                                    <th className="border p-3 bg-gray-100 text-left">Category</th>
+                                    <th className="border p-3 bg-gray-100 text-right">Amount</th>
+                                    <th className="border p-3 bg-gray-100 text-right">
 
-                                {/* feel free to change trash icon color or style */}
-
-                                <button onClick={() => setShowTrashIcon(!showTrashIcon)} className="p-2  border-green-500 rounded-md">
-                                <TrashIcon  className="w-5 h-5 text-red-400 hover:text-blue-500 hover:bg-yellow-500" />
-                                </button>
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {transactionList.map((transaction) => {
-                                const {description,date,amount,id} = transaction;
-                                const Date = date.split('T')[0]; 
-                                const [year, month, day] = Date.split('-')
-                                const formattedDate = `${month}/${day}/${year}`
-                                return(
-                                <tr
-                                    key={id} 
-                                    className="transition-colors hover:bg-gray-50"
-                                >
-                                    <td className="border p-3">{formattedDate}</td>
-                                    <td className="border p-3">{description}</td>
-                                    <td className="border p-3 text-green font-semibold text-right">
-                                        ${parseFloat(amount).toFixed(2)}
-                                    </td>
-                                    <td className="border p-3" style={{ width: '60px' }}>
                                         {/* feel free to change trash icon color or style */}
-                                        {showTrashIcon &&
-                                        <button onClick={() => {setShowConfirmation(!showConfirmation); setDeletID(id);}} className="p-2  border-green-500 rounded-md">
-                                            <TrashIcon  className="w-5 h-5 text-red-400 hover:text-blue-500 hover:bg-yellow-500" />
-                                            {showConfirmation &&
-                                                <DeleteConfirm
-                                                setTransactionList = {setTransactionList}
-                                                id = {deleteID}
-                                                setShowConfirmation = {setShowConfirmation}
-                                            />}
+
+                                        <button onClick={() => setShowTrashIcon(!showTrashIcon)} className="p-2  border-green-500 rounded-md">
+                                            <TrashIcon className="w-5 h-5 text-red-400 hover:text-blue-500 hover:bg-yellow-500" />
                                         </button>
-                                         }
-                                    </td>
+                                    </th>
                                 </tr>
-                            )})}
-                        </tbody>
-                    </table>
-                    <AddTransactionForm 
-                        fetchTransactions ={fetchTransactions}
-                    />
+                            </thead>
+                            <tbody>
+                                {transactionList.map((transaction) => {
+                                    const { description, date, amount, id } = transaction;
+                                    const Date = date.split('T')[0];
+                                    const [year, month, day] = Date.split('-')
+                                    const formattedDate = `${month}/${day}/${year}`
+                                    return (
+                                        <tr
+                                            key={id}
+                                            className="transition-colors hover:bg-gray-50"
+                                        >
+                                            <td className="border p-3">{formattedDate}</td>
+                                            <td className="border p-3">{description}</td>
+                                            <td className="border p-3 text-green font-semibold text-right">
+                                                ${parseFloat(amount).toFixed(2)}
+                                            </td>
+                                            <td className="border p-3" style={{ width: '60px' }}>
+                                                {/* feel free to change trash icon color or style */}
+                                                {showTrashIcon &&
+                                                    <button onClick={() => { setShowConfirmation(!showConfirmation); setDeletID(id); }} className="p-2  border-green-500 rounded-md">
+                                                        <TrashIcon className="w-5 h-5 text-red-400 hover:text-blue-500 hover:bg-yellow-500" />
+                                                        {showConfirmation &&
+                                                            <DeleteConfirm
+                                                                setTransactionList={setTransactionList}
+                                                                id={deleteID}
+                                                                setShowConfirmation={setShowConfirmation}
+                                                            />}
+                                                    </button>
+                                                }
+                                            </td>
+                                        </tr>
+                                    )
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="button-container">
+                        <AddTransactionForm
+                            fetchTransactions={fetchTransactions}
+                        />
+                    </div>
+
+
                 </div>
             </div></>
     );

--- a/src/pages/TransTable.jsx
+++ b/src/pages/TransTable.jsx
@@ -276,7 +276,7 @@ const TransTable = () => {
                             </tbody>
                         </table>
                     </div>
-                    <div className="button-container">
+                    <div className="button-container dialog-container">
                         <AddTransactionForm
                             fetchTransactions={fetchTransactions}
                         />


### PR DESCRIPTION
With this PR, the dashboard is a lot more responsive on smaller devices. Text, buttons, the table, etc. are all adjusted according to the device or screen window. Media queries were added to make it responsive.

Example:

<img height="300" alt="Screenshot 2023-12-04 at 2 04 47 AM" src="https://github.com/zikrya/Personal-Expense-Tracker/assets/42004630/e05a61d0-b338-47ff-92f7-9a5305ff334a">

<img height="300" alt="Screenshot 2023-12-04 at 2 04 57 AM" src="https://github.com/zikrya/Personal-Expense-Tracker/assets/42004630/e40ec348-4d5a-4b12-b1d3-5eecd9cf2e1e">

Here's how it looks on a bigger screen:

<img width="750" alt="Screenshot 2023-12-04 at 2 11 13 AM" src="https://github.com/zikrya/Personal-Expense-Tracker/assets/42004630/0a33bd86-7062-43f8-afcf-eea9b8239931">

For issue #98